### PR TITLE
feat: add pages property with width, height, and imageFit options

### DIFF
--- a/android/src/main/java/com/imagespdf/ImageScaling.java
+++ b/android/src/main/java/com/imagespdf/ImageScaling.java
@@ -1,0 +1,180 @@
+package com.imagespdf;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Matrix;
+import android.graphics.Paint;
+import android.graphics.Point;
+
+public class ImageScaling {
+  public static Bitmap scale(Bitmap image, Point size, String fit) throws Exception {
+    String imageFit = fit == null ? "none" : fit;
+
+    switch (imageFit) {
+      case "none":
+        return scaleWithNone(image, size);
+      case "contain":
+        return scaleWithContain(image, size);
+      case "cover":
+        return scaleWithCover(image, size);
+      case "fill":
+        return scaleWithFill(image, size);
+      default:
+        throw new Exception("Unknown scale fit: " + fit);
+    }
+  }
+
+  private static Bitmap scaleWithNone(Bitmap bitmap, Point size) {
+    // Create background bitmap.
+
+    Bitmap newBitmap = Bitmap.createBitmap(size.x, size.y, Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(newBitmap);
+
+    // Calculate new width and height.
+
+    int scaledWidth = bitmap.getWidth();
+    int scaledHeight = bitmap.getHeight();
+
+    // Apply transformations.
+
+    Matrix matrix = new Matrix();
+
+    float translateX = (size.x - scaledWidth) / 2f;
+    float translateY = (size.y - scaledHeight) / 2f;
+
+    matrix.postTranslate(translateX, translateY);
+
+    // Draw the bitmap.
+
+    Paint paint = new Paint(Paint.FILTER_BITMAP_FLAG);
+
+    canvas.drawBitmap(bitmap, matrix, paint);
+
+    return newBitmap;
+  }
+
+  private static Bitmap scaleWithContain(Bitmap bitmap, Point size) {
+    // Create background bitmap.
+
+    Bitmap newBitmap = Bitmap.createBitmap(size.x, size.y, Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(newBitmap);
+
+    // Calculate new width and height.
+
+    int width = bitmap.getWidth();
+    int height = bitmap.getHeight();
+
+    float aspectRatio = (float) width / height;
+    float targetAspectRatio = (float) size.x / size.y;
+
+    int scaledWidth, scaledHeight;
+    if (aspectRatio > targetAspectRatio) {
+      scaledWidth = size.x;
+      scaledHeight = (int) (size.x / aspectRatio);
+    } else {
+      scaledWidth = (int) (size.y * aspectRatio);
+      scaledHeight = size.y;
+    }
+
+    // Apply transformations.
+
+    Matrix matrix = new Matrix();
+
+    float scaleX = (float) scaledWidth / width;
+    float scaleY = (float) scaledHeight / height;
+
+    matrix.postScale(scaleX, scaleY);
+
+    float translateX = (size.x - scaledWidth) / 2f;
+    float translateY = (size.y - scaledHeight) / 2f;
+
+    matrix.postTranslate(translateX, translateY);
+
+    // Draw the bitmap.
+
+    Paint paint = new Paint(Paint.FILTER_BITMAP_FLAG);
+
+    canvas.drawBitmap(bitmap, matrix, paint);
+
+    return newBitmap;
+  }
+
+  private static Bitmap scaleWithCover(Bitmap bitmap, Point size) {
+    // Create background bitmap.
+
+    Bitmap newBitmap = Bitmap.createBitmap(size.x, size.y, Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(newBitmap);
+
+    // Calculate new width and height.
+
+    int width = bitmap.getWidth();
+    int height = bitmap.getHeight();
+
+    float aspectRatio = (float) width / height;
+    float targetAspectRatio = (float) size.x / size.y;
+
+    float scaleFactor;
+    if (aspectRatio > targetAspectRatio) {
+      scaleFactor = (float) size.y / height;
+    } else {
+      scaleFactor = (float) size.x / width;
+    }
+
+    int scaledWidth = Math.round(width * scaleFactor);
+    int scaledHeight = Math.round(height * scaleFactor);
+
+    // Apply transformations.
+
+    Matrix matrix = new Matrix();
+
+    matrix.postScale(scaleFactor, scaleFactor);
+
+    float translateX = (size.x - scaledWidth) / 2f;
+    float translateY = (size.y - scaledHeight) / 2f;
+
+    matrix.postTranslate(translateX, translateY);
+
+    // Draw the bitmap.
+
+    Paint paint = new Paint(Paint.FILTER_BITMAP_FLAG);
+
+    canvas.drawBitmap(bitmap, matrix, paint);
+
+    return newBitmap;
+  }
+
+  private static Bitmap scaleWithFill(Bitmap bitmap, Point size) {
+    // Create background bitmap.
+
+    Bitmap newBitmap = Bitmap.createBitmap(size.x, size.y, Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(newBitmap);
+
+    // Calculate new width and height.
+
+    int width = bitmap.getWidth();
+    int height = bitmap.getHeight();
+
+    int scaledWidth = size.x;
+    int scaledHeight = size.y;
+
+    // Apply transformations.
+
+    Matrix matrix = new Matrix();
+
+    float scaleX = (float) scaledWidth / width;
+    float scaleY = (float) scaledHeight / height;
+
+    matrix.postScale(scaleX, scaleY);
+
+    // Draw the bitmap.
+
+    Paint paint = new Paint(Paint.FILTER_BITMAP_FLAG);
+
+    canvas.drawBitmap(bitmap, matrix, paint);
+
+    return newBitmap;
+  }
+}
+
+
+

--- a/android/src/main/java/com/imagespdf/ImageScaling.java
+++ b/android/src/main/java/com/imagespdf/ImageScaling.java
@@ -6,6 +6,8 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Point;
 
+// TODO: ImagePosition
+
 public class ImageScaling {
   public static Bitmap scale(Bitmap image, Point size, String fit) throws Exception {
     String imageFit = fit == null ? "none" : fit;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,12 +1,25 @@
 import * as React from 'react';
 
-import { createPdf } from 'react-native-images-to-pdf';
+import { createPdf, ImageFit, Page } from 'react-native-images-to-pdf';
 import { launchImageLibrary } from 'react-native-image-picker';
 import { pickDirectory } from 'react-native-document-picker';
-import { Button, StyleSheet, View } from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 export default function App() {
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [outputFilename, setOutputFilename] = React.useState('Example.pdf');
+  const [width, setWidth] = React.useState(594);
+  const [height, setHeight] = React.useState(842);
+  const [imageFit, setImageFit] = React.useState<ImageFit>('cover');
+
   const selectImages = async () => {
+    setIsLoading(true);
     try {
       const result = await launchImageLibrary({
         mediaType: 'photo',
@@ -14,9 +27,6 @@ export default function App() {
       });
 
       if (result.assets) {
-        const assets = result.assets;
-        const imagePaths = assets.map((asset) => asset.uri as string);
-
         const resultPickDir = await pickDirectory();
 
         if (!resultPickDir) {
@@ -24,22 +34,85 @@ export default function App() {
         }
 
         const outputDirectory = resultPickDir.uri;
-        const outputFilename = 'Example.pdf';
+
+        const pages = result.assets.map((asset) => {
+          const page: Page = {
+            imagePath: asset.uri as string,
+            imageFit,
+            width,
+            height,
+          };
+
+          return page;
+        });
 
         await createPdf({
-          imagePaths,
+          imagePaths: [],
           outputDirectory,
           outputFilename,
+          pages,
         });
       }
     } catch (e) {
       console.error(e);
     }
+
+    setIsLoading(false);
   };
 
   return (
     <View style={styles.root}>
-      <Button title="Select images" onPress={selectImages} />
+      <TouchableOpacity style={styles.button} onPress={selectImages}>
+        <Text style={styles.buttonText}>Press to select images</Text>
+      </TouchableOpacity>
+
+      <TextInput
+        style={styles.input}
+        placeholder="Output file name"
+        value={outputFilename}
+        onChangeText={setOutputFilename}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Page width"
+        defaultValue={height ? height.toString() : ''}
+        onChangeText={(text) => {
+          const n = parseFloat(text);
+          if (!Number.isNaN(n)) {
+            setWidth(n);
+          }
+        }}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Page height"
+        defaultValue={width ? width.toString() : ''}
+        onChangeText={(text) => {
+          const n = parseFloat(text);
+          if (!Number.isNaN(n)) {
+            setHeight(n);
+          }
+        }}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Image fit"
+        defaultValue={imageFit}
+        onChangeText={(text) => {
+          const f = text.toLowerCase();
+          switch (f) {
+            case 'none':
+            case 'cover':
+            case 'contain':
+            case 'fill':
+              setImageFit(f);
+          }
+        }}
+      />
+
+      {isLoading ? (
+        <Text style={styles.text}>Creating PDF document...</Text>
+      ) : null}
     </View>
   );
 }
@@ -49,5 +122,17 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  button: {
+    marginBottom: 20,
+  },
+  buttonText: {
+    color: 'blue',
+  },
+  text: {
+    color: 'gray',
+  },
+  input: {
+    marginBottom: 20,
   },
 });

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,10 +13,20 @@ import {
 
 export default function App() {
   const [isLoading, setIsLoading] = React.useState(false);
-  const [outputFilename, setOutputFilename] = React.useState('Example.pdf');
-  const [width, setWidth] = React.useState(594);
-  const [height, setHeight] = React.useState(842);
-  const [imageFit, setImageFit] = React.useState<ImageFit>('cover');
+  const [width, setWidth] = React.useState<number | undefined>(594);
+  const [height, setHeight] = React.useState<number | undefined>(842);
+  const [imageFit, setImageFit] = React.useState<ImageFit | undefined>('cover');
+
+  const parts: string[] = [];
+  if (width) {
+    parts.push(`${width}w`);
+  }
+  if (height) {
+    parts.push(`${height}h`);
+  }
+  parts.push(imageFit ?? 'none');
+
+  const outputFilename = parts.join('-') + '.pdf';
 
   const selectImages = async () => {
     setIsLoading(true);
@@ -47,7 +57,6 @@ export default function App() {
         });
 
         await createPdf({
-          imagePaths: [],
           outputDirectory,
           outputFilename,
           pages,
@@ -62,36 +71,22 @@ export default function App() {
 
   return (
     <View style={styles.root}>
-      <TouchableOpacity style={styles.button} onPress={selectImages}>
-        <Text style={styles.buttonText}>Press to select images</Text>
-      </TouchableOpacity>
-
-      <TextInput
-        style={styles.input}
-        placeholder="Output file name"
-        value={outputFilename}
-        onChangeText={setOutputFilename}
-      />
       <TextInput
         style={styles.input}
         placeholder="Page width"
-        defaultValue={height ? height.toString() : ''}
+        defaultValue={width ? width.toString() : ''}
         onChangeText={(text) => {
           const n = parseFloat(text);
-          if (!Number.isNaN(n)) {
-            setWidth(n);
-          }
+          setWidth(Number.isNaN(n) ? undefined : n);
         }}
       />
       <TextInput
         style={styles.input}
         placeholder="Page height"
-        defaultValue={width ? width.toString() : ''}
+        defaultValue={height ? height.toString() : ''}
         onChangeText={(text) => {
           const n = parseFloat(text);
-          if (!Number.isNaN(n)) {
-            setHeight(n);
-          }
+          setHeight(Number.isNaN(n) ? undefined : n);
         }}
       />
       <TextInput
@@ -106,12 +101,24 @@ export default function App() {
             case 'contain':
             case 'fill':
               setImageFit(f);
+              break;
+            default:
+              setImageFit(undefined);
           }
         }}
       />
 
+      <TouchableOpacity style={styles.button} onPress={selectImages}>
+        <Text style={styles.buttonText}>Press to select images</Text>
+      </TouchableOpacity>
+
+      <Text>Page width: {width ?? 'undefined'}</Text>
+      <Text>Page height: {height ?? 'undefined'}</Text>
+      <Text>Image fit: {imageFit ?? 'undefined'}</Text>
+      <Text style={styles.text}>Output file name: {outputFilename}</Text>
+
       {isLoading ? (
-        <Text style={styles.text}>Creating PDF document...</Text>
+        <Text style={styles.loadingText}>Creating PDF document...</Text>
       ) : null}
     </View>
   );
@@ -130,6 +137,9 @@ const styles = StyleSheet.create({
     color: 'blue',
   },
   text: {
+    marginBottom: 20,
+  },
+  loadingText: {
     color: 'gray',
   },
   input: {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -148,6 +148,7 @@ const styles = StyleSheet.create({
     borderColor: '#32a9d9',
     borderRadius: 10,
     paddingHorizontal: 10,
+    minHeight: 40,
   },
   button: {
     marginBottom: 20,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -74,6 +74,7 @@ export default function App() {
       <TextInput
         style={styles.input}
         placeholder="Page width"
+        keyboardType="numeric"
         defaultValue={width ? width.toString() : ''}
         onChangeText={(text) => {
           const n = parseFloat(text);
@@ -83,6 +84,7 @@ export default function App() {
       <TextInput
         style={styles.input}
         placeholder="Page height"
+        keyboardType="numeric"
         defaultValue={height ? height.toString() : ''}
         onChangeText={(text) => {
           const n = parseFloat(text);
@@ -108,18 +110,28 @@ export default function App() {
         }}
       />
 
-      <TouchableOpacity style={styles.button} onPress={selectImages}>
-        <Text style={styles.buttonText}>Press to select images</Text>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={selectImages}
+        disabled={isLoading}
+      >
+        <Text style={styles.buttonText}>
+          {isLoading ? 'Loading...' : 'Press to select images'}
+        </Text>
       </TouchableOpacity>
 
-      <Text>Page width: {width ?? 'undefined'}</Text>
-      <Text>Page height: {height ?? 'undefined'}</Text>
-      <Text>Image fit: {imageFit ?? 'undefined'}</Text>
-      <Text style={styles.text}>Output file name: {outputFilename}</Text>
-
-      {isLoading ? (
-        <Text style={styles.loadingText}>Creating PDF document...</Text>
-      ) : null}
+      <Text>
+        <Text style={styles.bold}>Page width:</Text> {width ?? 'image width'}
+      </Text>
+      <Text>
+        <Text style={styles.bold}>Page height:</Text> {height ?? 'image height'}
+      </Text>
+      <Text>
+        <Text style={styles.bold}>Image fit:</Text> {imageFit ?? 'none'}
+      </Text>
+      <Text>
+        <Text style={styles.bold}>Output file name:</Text> {outputFilename}
+      </Text>
     </View>
   );
 }
@@ -128,21 +140,28 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     justifyContent: 'center',
-    alignItems: 'center',
-  },
-  button: {
-    marginBottom: 20,
-  },
-  buttonText: {
-    color: 'blue',
-  },
-  text: {
-    marginBottom: 20,
-  },
-  loadingText: {
-    color: 'gray',
+    padding: 20,
   },
   input: {
     marginBottom: 20,
+    borderWidth: 1,
+    borderColor: '#32a9d9',
+    borderRadius: 10,
+    paddingHorizontal: 10,
+  },
+  button: {
+    marginBottom: 20,
+    backgroundColor: '#32a9d9',
+    padding: 10,
+    borderRadius: 10,
+  },
+  buttonText: {
+    color: 'white',
+    fontWeight: 'bold',
+    textTransform: 'uppercase',
+    textAlign: 'center',
+  },
+  bold: {
+    fontWeight: 'bold',
   },
 });

--- a/ios/CreatePdfError.swift
+++ b/ios/CreatePdfError.swift
@@ -11,5 +11,5 @@ enum CreatePdfError: Error {
   case pdfWriteError(error: Error)
   case outputDirectoryDoesNotExist
   case outputDirectoryIsNotWritable
-  case imagePathsIsEmpty
+  case pagesIsEmpty
 }

--- a/ios/CreatePdfError.swift
+++ b/ios/CreatePdfError.swift
@@ -11,5 +11,5 @@ enum CreatePdfError: Error {
   case pdfWriteError(error: Error)
   case outputDirectoryDoesNotExist
   case outputDirectoryIsNotWritable
-  case pagesIsEmpty
+  case noImagesProvided
 }

--- a/ios/CreatePdfOptions.swift
+++ b/ios/CreatePdfOptions.swift
@@ -21,7 +21,6 @@ struct Page: Decodable {
 }
 
 struct CreatePdfOptions: Decodable {
-  let imagePaths: [String]
   let outputDirectory: String
   let outputFilename: String
   let pages: [Page]

--- a/ios/CreatePdfOptions.swift
+++ b/ios/CreatePdfOptions.swift
@@ -6,8 +6,23 @@
 //  Copyright © 2023 Facebook. All rights reserved.
 //
 
+enum ImageFit: String, Decodable {
+  case none
+  case fill
+  case contain
+  case cover
+}
+
+struct Page: Decodable {
+  let imagePath: String
+  let imageFit: ImageFit?
+  let width: Double?
+  let height: Double?
+}
+
 struct CreatePdfOptions: Decodable {
   let imagePaths: [String]
   let outputDirectory: String
   let outputFilename: String
+  let pages: [Page]
 }

--- a/ios/ImagesPdf.swift
+++ b/ios/ImagesPdf.swift
@@ -5,7 +5,7 @@ class ImagesPdf: NSObject {
   let E_PDF_PAGE_CREATE_ERROR = "PDF_PAGE_CREATE_ERROR"
   let E_OUTPUT_DIRECTORY_DOES_NOT_EXIST = "OUTPUT_DIRECTORY_DOES_NOT_EXIST"
   let E_OUTPUT_DIRECTORY_IS_NOT_WRITABLE = "OUTPUT_DIRECTORY_IS_NOT_WRITABLE"
-  let E_PAGES_IS_EMPTY = "PAGES_IS_EMPTY"
+  let E_NO_IMAGES_PROVIDED = "NO_IMAGES_PROVIDED"
   
   @objc
   func createPdf(_ options: NSDictionary, resolver resolve:RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
@@ -17,7 +17,7 @@ class ImagesPdf: NSObject {
       let pages = createPdfOptions.pages
       
       if pages.isEmpty {
-        throw CreatePdfError.pagesIsEmpty
+        throw CreatePdfError.noImagesProvided
       }
       
       let data = try renderPdfData(pages)
@@ -27,9 +27,9 @@ class ImagesPdf: NSObject {
                                        outputFilename: outputFilename)
       
       resolve(outputUrl.absoluteString)
-    } catch CreatePdfError.pagesIsEmpty {
-      reject(E_PAGES_IS_EMPTY,
-             "pages is empty.",
+    } catch CreatePdfError.noImagesProvided {
+      reject(E_NO_IMAGES_PROVIDED,
+             "No images provided.",
              nil)
     } catch CreatePdfError.outputDirectoryIsNotWritable {
       reject(E_OUTPUT_DIRECTORY_IS_NOT_WRITABLE,

--- a/ios/ImagesPdf.xcodeproj/project.pbxproj
+++ b/ios/ImagesPdf.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		527793C229B68D9100DA97C8 /* CreatePdfOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527793C129B68D8700DA97C8 /* CreatePdfOptions.swift */; };
 		527793C629B6E17300DA97C8 /* CreatePdfError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527793C529B6E17300DA97C8 /* CreatePdfError.swift */; };
+		528FC83B2A3A80D400B91589 /* UIImage+Scaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528FC83A2A3A80D400B91589 /* UIImage+Scaling.swift */; };
 		F4FF95D7245B92E800C19C63 /* ImagesPdf.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* ImagesPdf.swift */; };
 /* End PBXBuildFile section */
 
@@ -28,6 +29,7 @@
 		134814201AA4EA6300B7C361 /* libImagesPdf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libImagesPdf.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		527793C129B68D8700DA97C8 /* CreatePdfOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePdfOptions.swift; sourceTree = "<group>"; };
 		527793C529B6E17300DA97C8 /* CreatePdfError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePdfError.swift; sourceTree = "<group>"; };
+		528FC83A2A3A80D400B91589 /* UIImage+Scaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Scaling.swift"; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* ImagesPdf.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImagesPdf.m; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* ImagesPdf-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ImagesPdf-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* ImagesPdf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesPdf.swift; sourceTree = "<group>"; };
@@ -55,6 +57,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				528FC83A2A3A80D400B91589 /* UIImage+Scaling.swift */,
 				527793C529B6E17300DA97C8 /* CreatePdfError.swift */,
 				527793C129B68D8700DA97C8 /* CreatePdfOptions.swift */,
 				F4FF95D6245B92E800C19C63 /* ImagesPdf.swift */,
@@ -122,6 +125,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F4FF95D7245B92E800C19C63 /* ImagesPdf.swift in Sources */,
+				528FC83B2A3A80D400B91589 /* UIImage+Scaling.swift in Sources */,
 				527793C629B6E17300DA97C8 /* CreatePdfError.swift in Sources */,
 				527793C229B68D9100DA97C8 /* CreatePdfOptions.swift in Sources */,
 			);

--- a/ios/UIImage+Scaling.swift
+++ b/ios/UIImage+Scaling.swift
@@ -16,56 +16,89 @@ extension UIImage {
     
     switch fit {
     case .none:
-      let origin = CGPoint(
-        x: (size.width - self.size.width) / 2.0,
-        y: (size.height - self.size.height) / 2.0
-      )
-      
-      UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
-      defer { UIGraphicsEndImageContext() }
-      
-      self.draw(in: CGRect(origin: origin, size: self.size))
-      let newImage = UIGraphicsGetImageFromCurrentImageContext()
-      
-      return newImage
-      
-    case .contain, .cover:
-      let widthRatio = size.width / self.size.width
-      let heightRatio = size.height / self.size.height
-      let scaleFactor: CGFloat
-      
-      if fit == .contain {
-        scaleFactor = min(widthRatio, heightRatio)
-      } else {
-        scaleFactor = max(widthRatio, heightRatio)
-      }
-      
-      let scaledSize = CGSize(
-        width: self.size.width * scaleFactor,
-        height: self.size.height * scaleFactor
-      )
-      
-      let origin = CGPoint(
-        x: (size.width - scaledSize.width) / 2.0,
-        y: (size.height - scaledSize.height) / 2.0
-      )
-      
-      UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
-      defer { UIGraphicsEndImageContext() }
-      
-      self.draw(in: CGRect(origin: origin, size: scaledSize))
-      let newImage = UIGraphicsGetImageFromCurrentImageContext()
-      
-      return newImage
-      
+      return scaleWithNone(to: size)
+    case .contain:
+      return scaleWithContain(to: size)
+    case .cover:
+      return scaleWithCover(to: size)
     case .fill:
-      UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
-      defer { UIGraphicsEndImageContext() }
-      
-      self.draw(in: CGRect(origin: .zero, size: size))
-      let newImage = UIGraphicsGetImageFromCurrentImageContext()
-      
-      return newImage
+      return scaleWithFill(to: size)
     }
+  }
+  
+  private func scaleWithNone(to size: CGSize) -> UIImage? {
+    let scaledWidth = self.size.width
+    
+    let origin = CGPoint(
+      x: (size.width - self.size.width) / 2.0,
+      y: (size.height - self.size.height) / 2.0
+    )
+    
+    UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+    defer { UIGraphicsEndImageContext() }
+    
+    self.draw(in: CGRect(origin: origin, size: self.size))
+    
+    return UIGraphicsGetImageFromCurrentImageContext()
+  }
+  
+  private func scaleWithContain(to size: CGSize) -> UIImage? {
+    let aspectRatio = self.size.width / self.size.height
+    let targetAspectRatio = size.width / size.height
+    
+    var scaledSize = CGSize(width: size.width, height: size.height)
+    if aspectRatio > targetAspectRatio {
+      scaledSize.height = size.width / aspectRatio
+    } else {
+      scaledSize.width = size.height * aspectRatio
+    }
+    
+    let origin = CGPoint(
+      x: (size.width - scaledSize.width) / 2.0,
+      y: (size.height - scaledSize.height) / 2.0
+    )
+    
+    UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+    defer { UIGraphicsEndImageContext() }
+    
+    self.draw(in: CGRect(origin: origin, size: scaledSize))
+    
+    return UIGraphicsGetImageFromCurrentImageContext()
+  }
+  
+  private func scaleWithCover(to size: CGSize) -> UIImage? {
+    let aspectRatio = self.size.width / self.size.height
+    let targetAspectRatio = size.width / size.height
+    
+    var scaleFactor = size.width / self.size.width
+    if aspectRatio > targetAspectRatio {
+      scaleFactor = size.height / self.size.height
+    }
+    
+    let scaledSize = CGSize(
+      width: self.size.width * scaleFactor,
+      height: self.size.height * scaleFactor
+    )
+    
+    let origin = CGPoint(
+      x: (size.width - scaledSize.width) / 2.0,
+      y: (size.height - scaledSize.height) / 2.0
+    )
+    
+    UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+    defer { UIGraphicsEndImageContext() }
+    
+    self.draw(in: CGRect(origin: origin, size: scaledSize))
+    
+    return  UIGraphicsGetImageFromCurrentImageContext()
+  }
+  
+  private func scaleWithFill(to size: CGSize) -> UIImage? {
+    UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+    defer { UIGraphicsEndImageContext() }
+    
+    self.draw(in: CGRect(origin: .zero, size: size))
+    
+    return UIGraphicsGetImageFromCurrentImageContext()
   }
 }

--- a/ios/UIImage+Scaling.swift
+++ b/ios/UIImage+Scaling.swift
@@ -1,0 +1,71 @@
+//
+//  UIImage+Scaling.swift
+//  ImagesPdf
+//
+//  Created by Gabriel Emilio Lopez Ojeda on 14/06/23.
+//  Copyright © 2023 Facebook. All rights reserved.
+//
+
+import UIKit
+
+// TODO: ImagePosition
+
+extension UIImage {
+  func scale(to size: CGSize, with fit: ImageFit?) -> UIImage? {
+    let fit = fit ?? .none
+    
+    switch fit {
+    case .none:
+      let origin = CGPoint(
+        x: (size.width - self.size.width) / 2.0,
+        y: (size.height - self.size.height) / 2.0
+      )
+      
+      UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+      defer { UIGraphicsEndImageContext() }
+      
+      self.draw(in: CGRect(origin: origin, size: self.size))
+      let newImage = UIGraphicsGetImageFromCurrentImageContext()
+      
+      return newImage
+      
+    case .contain, .cover:
+      let widthRatio = size.width / self.size.width
+      let heightRatio = size.height / self.size.height
+      let scaleFactor: CGFloat
+      
+      if fit == .contain {
+        scaleFactor = min(widthRatio, heightRatio)
+      } else {
+        scaleFactor = max(widthRatio, heightRatio)
+      }
+      
+      let scaledSize = CGSize(
+        width: self.size.width * scaleFactor,
+        height: self.size.height * scaleFactor
+      )
+      
+      let origin = CGPoint(
+        x: (size.width - scaledSize.width) / 2.0,
+        y: (size.height - scaledSize.height) / 2.0
+      )
+      
+      UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+      defer { UIGraphicsEndImageContext() }
+      
+      self.draw(in: CGRect(origin: origin, size: scaledSize))
+      let newImage = UIGraphicsGetImageFromCurrentImageContext()
+      
+      return newImage
+      
+    case .fill:
+      UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+      defer { UIGraphicsEndImageContext() }
+      
+      self.draw(in: CGRect(origin: .zero, size: size))
+      let newImage = UIGraphicsGetImageFromCurrentImageContext()
+      
+      return newImage
+    }
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,14 +26,40 @@ export type Page = {
   height?: number;
 };
 
-export interface CreatePdfOptions {
-  outputDirectory: string;
-  outputFilename: string;
-  pages: Page[];
-}
+export type CreatePdfOptions =
+  | {
+      outputDirectory: string;
+      outputFilename: string;
+      pages: Array<Page | string>;
+      imagePaths?: undefined;
+    }
+  | {
+      outputDirectory: string;
+      outputFilename: string;
+      pages?: undefined;
+      /**
+       * @deprecated Use the `pages` property instead.
+       */
+      imagePaths: string[];
+    };
 
 export function createPdf(options: CreatePdfOptions): Promise<string> {
-  return ImagesPdf.createPdf(options);
+  const { pages, imagePaths, ...opts } = options;
+
+  const mappedPages = (imagePaths || pages || []).map<Page>((e) => {
+    if (typeof e === 'string') {
+      return {
+        imagePath: e,
+      };
+    }
+
+    return e;
+  });
+
+  return ImagesPdf.createPdf({
+    ...opts,
+    pages: mappedPages,
+  });
 }
 
 export function getDocumentsDirectory(): Promise<string> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,10 +17,20 @@ const ImagesPdf = NativeModules.ImagesPdf
       }
     );
 
+export type ImageFit = 'none' | 'fill' | 'contain' | 'cover';
+
+export type Page = {
+  imagePath: string;
+  imageFit?: ImageFit;
+  width?: number;
+  height?: number;
+};
+
 export interface CreatePdfOptions {
   imagePaths: string[];
   outputDirectory: string;
   outputFilename: string;
+  pages: Page[];
 }
 
 export function createPdf(options: CreatePdfOptions): Promise<string> {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,6 @@ export type Page = {
 };
 
 export interface CreatePdfOptions {
-  imagePaths: string[];
   outputDirectory: string;
   outputFilename: string;
   pages: Page[];


### PR DESCRIPTION
- Added the `pages` property to the `CreatePdfOptions` type, allowing customization of each page's layout.
- The `pages` property accepts an array of Page objects with options for width, height, and imageFit.
- Updated the PDF generation logic to utilize the `pages` property and apply the specified layouts.